### PR TITLE
Update tests for python3.9

### DIFF
--- a/src/tests.py
+++ b/src/tests.py
@@ -448,7 +448,8 @@ class MersenneTwister_TestBasicOps(TestBasicOps):
         self.assertRaises(TypeError, self.gen.getrandbits)
         self.assertRaises(TypeError, self.gen.getrandbits, 'a')
         self.assertRaises(TypeError, self.gen.getrandbits, 1, 2)
-        self.assertRaises(ValueError, self.gen.getrandbits, 0)
+        if sys.version_info < (3, 9):
+            self.assertRaises(ValueError, self.gen.getrandbits, 0)
         self.assertRaises(ValueError, self.gen.getrandbits, -1)
 
     def test_randbelow_logic(self, _log=log, int=int):


### PR DESCRIPTION
`random.getrandbits(0)` no longer raises a value error on python3.9