### PR TITLE
Enable test run with Python 3.13 - unittest.makeSuite() was removed

### DIFF
--- a/src/tests.py
+++ b/src/tests.py
@@ -591,12 +591,13 @@ class TestModule(unittest.TestCase):
 #        print(counts)
 
 def test_suite():
-    return unittest.TestSuite((
-            unittest.makeSuite(WichmannHill_TestBasicOps),
-            unittest.makeSuite(MersenneTwister_TestBasicOps),
-            unittest.makeSuite(TestDistributions),
-            unittest.makeSuite(TestModule)
-            ))
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(WichmannHill_TestBasicOps))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(MersenneTwister_TestBasicOps))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestDistributions))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestModule))
+    return suite
+
 
 if __name__ == "__main__":
     test_main(verbose=True)


### PR DESCRIPTION
I've verified that this fix enables to build package and run the test suite when building an RPM for Fedora Linux.